### PR TITLE
Feature/key chaining

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 )
 
 // DecodeInfo TODO
@@ -45,21 +46,33 @@ type DecodeLevel int
 
 // Level TODO
 const (
-	LevelRoot DecodeLevel = iota
+	// Public levels
+	LevelInvalid DecodeLevel = iota
 	LevelQuery
 	LevelField
 	LevelKey
 	LevelValueList
 	LevelValue
+
+	// TODO: This internal level stuff makes acting on DecodeInfo annoying.
+	// Maybe try a second type like:
+	// type DecodeSetLevel|DecodePublicLevel|... DecodeLevel
+
+	// Internal levels
+	levelRoot
+	levelKeyChain
 )
 
 var decodeLevelNames = map[DecodeLevel]string{
-	LevelRoot:      "root",
+	LevelInvalid:   "invalid",
 	LevelQuery:     "query",
 	LevelField:     "field",
 	LevelKey:       "key",
 	LevelValueList: "value list",
 	LevelValue:     "value",
+
+	levelRoot:     "root",
+	levelKeyChain: "key chain",
 }
 
 func (dl DecodeLevel) String() string { return decodeLevelNames[dl] }
@@ -109,9 +122,10 @@ func ensureSettable(val reflect.Value) reflect.Value {
 
 // Decoder TODO
 type Decoder struct {
-	separators ConfigSeparate
-	baseModes  levelModes
-	logTrace   Trace
+	baseModes         levelModes
+	ignoreInvalidKeys bool
+	logTrace          Trace
+	separators        ConfigSeparate
 
 	converter    *converter
 	structParser *structParser
@@ -155,9 +169,9 @@ func (d *Decoder) Decode(level DecodeLevel, input string, v interface{}, traces 
 
 	switch {
 	case val.Kind() != reflect.Ptr:
-		return LevelRoot.newError("non-pointer target", input, val)
+		return levelRoot.newError("non-pointer target", input, val)
 	case val.IsNil():
-		return LevelRoot.newError("nil pointer target", input, val)
+		return levelRoot.newError("nil pointer target", input, val)
 	}
 
 	if d.logTrace != nil {
@@ -390,6 +404,8 @@ func (d *Decoder) handleContainers(level DecodeLevel, raw string, val reflect.Va
 			return true, level.newError("insufficient destination array length", raw, val)
 		}
 
+		// TODO: Double check but, like struct, shouldn't need to create a new Array
+		// here if val.IsZero() is true??? Maybe??? Are arrays still reference types like slices???
 		newArray := reflect.New(val.Type()).Elem()
 
 		for i, rawItem := range rawItems {
@@ -402,8 +418,6 @@ func (d *Decoder) handleContainers(level DecodeLevel, raw string, val reflect.Va
 		return true, nil
 
 	case reflect.Map:
-		// TODO: Any way to make all the shouldReplace checks more elegant?
-
 		var rawFields []string
 
 		switch level {
@@ -416,12 +430,7 @@ func (d *Decoder) handleContainers(level DecodeLevel, raw string, val reflect.Va
 			return false, nil
 		}
 
-		var (
-			dstMap   reflect.Value
-			keyType  = val.Type().Key()
-			elemType = val.Type().Elem()
-		)
-
+		var dstMap reflect.Value
 		if shouldReplace {
 			dstMap = reflect.MakeMap(val.Type())
 		} else {
@@ -430,27 +439,13 @@ func (d *Decoder) handleContainers(level DecodeLevel, raw string, val reflect.Va
 
 		for _, rawField := range rawFields {
 			var (
-				newKey               = reflect.New(keyType).Elem()
 				rawKey, rawValueList = d.separators.KeyVals(rawField)
+				rawKeyChain          = d.separators.KeyChain(rawKey)
 			)
 
-			if err := d.decode(LevelKey, rawKey, newKey, state.child()); err != nil {
+			if err := d.decodeKeyChain(rawKeyChain, rawValueList, dstMap, state.child()); err != nil {
 				return true, err
 			}
-
-			elem := dstMap.MapIndex(newKey)
-			if !elem.IsValid() {
-				// Map does not contain newKey
-				elem = reflect.New(elemType).Elem()
-			} else {
-				elem = ensureSettable(elem)
-			}
-
-			if err := d.decode(LevelValueList, rawValueList, elem, state.child()); err != nil {
-				return true, err
-			}
-
-			dstMap.SetMapIndex(newKey, elem)
 		}
 
 		if shouldReplace {
@@ -460,8 +455,6 @@ func (d *Decoder) handleContainers(level DecodeLevel, raw string, val reflect.Va
 		return true, nil
 
 	case reflect.Struct:
-		// TODO: Any way to make all the shouldReplace checks more elegant?
-
 		if level != LevelQuery && level != LevelField {
 			// Only query and field levels support structs
 			return false, nil
@@ -470,14 +463,10 @@ func (d *Decoder) handleContainers(level DecodeLevel, raw string, val reflect.Va
 		var dstStruct reflect.Value
 
 		if shouldReplace {
+			// TODO: We don't really need to create a new struct if val.IsZero() is true here
 			dstStruct = reflect.New(val.Type()).Elem()
 		} else {
 			dstStruct = val
-		}
-
-		items, parseErr := d.structParser.parse(dstStruct)
-		if parseErr != nil {
-			return true, level.wrapError(parseErr, raw, val)
 		}
 
 		switch level {
@@ -485,23 +474,21 @@ func (d *Decoder) handleContainers(level DecodeLevel, raw string, val reflect.Va
 			rawFields := d.separators.Fields(raw)
 			for _, rawField := range rawFields {
 				var (
-					rawKey, rawValueList      = d.separators.KeyVals(rawField)
-					unescapedKey, unescapeErr = d.converter.Unescape(rawKey)
+					rawKey, rawValueList = d.separators.KeyVals(rawField)
+					rawKeyChain          = d.separators.KeyChain(rawKey)
 				)
 
-				if unescapeErr != nil {
-					return true, level.wrapError(unescapeErr, raw, val)
-				}
-
-				if item, ok := items[unescapedKey]; ok {
-					childState := state.childWithSetMode(LevelValueList, item.setOpts)
-					if err := d.decode(LevelValueList, rawValueList, item.val, childState); err != nil {
-						return true, err
-					}
+				if err := d.decodeKeyChain(rawKeyChain, rawValueList, dstStruct, state.child()); err != nil {
+					return true, err
 				}
 			}
 
 		case LevelField:
+			items, parseErr := d.structParser.parse(dstStruct)
+			if parseErr != nil {
+				return true, level.wrapError(parseErr, raw, val)
+			}
+
 			rawKey, rawValueList := d.separators.KeyVals(raw)
 
 			// TODO: magic => constant
@@ -529,4 +516,104 @@ func (d *Decoder) handleContainers(level DecodeLevel, raw string, val reflect.Va
 	}
 
 	return false, nil
+}
+
+func (d *Decoder) decodeKeyChain(rawChain []string, raw string, val reflect.Value, state *decodeState) error {
+	// Shuttle work off to decode() once key chain is exhausted
+	if len(rawChain) < 1 {
+		return d.decode(LevelValueList, raw, val, state)
+	}
+
+	// TODO: We're breaking the nice structured nature of DecodeInfo with this
+	// custom string formatting of "input"
+	//
+	// Also doing unneeded format work when trace is a no-op. Need to reconsider
+	// just checking for nil rather than a noop function for "no trace"
+	inputStr := fmt.Sprintf("%s | %s", strings.Join(rawChain, ", "), raw)
+
+	state.trace.Mark(levelKeyChain, inputStr, val)
+
+	kind := val.Kind()
+
+	if kind == reflect.Ptr {
+		if val.IsNil() {
+			val.Set(reflect.New(val.Type().Elem()))
+		}
+
+		return d.decodeKeyChain(rawChain, raw, val.Elem(), state.child())
+	}
+
+	rawKey, remainingChain := rawChain[0], rawChain[1:]
+
+	if kind == reflect.Map {
+		if val.IsZero() {
+			val.Set(reflect.MakeMap(val.Type()))
+		}
+
+		var (
+			keyType  = val.Type().Key()
+			elemType = val.Type().Elem()
+			newKey   = reflect.New(keyType).Elem()
+		)
+
+		if err := d.decode(LevelKey, rawKey, newKey, state.child()); err != nil {
+			return err
+		}
+
+		elem := val.MapIndex(newKey)
+		if !elem.IsValid() {
+			// Map does not contain newKey
+			elem = reflect.New(elemType).Elem()
+		} else {
+			// NOTE/TODO?
+			// This is potentially a heavy cost, but optimizing might be very complex
+			// (namely breaking the very useful "always .CanSet()" heuristic)
+			//
+			// Elaboration example: long chain of non-zero maps terminating in a
+			// pointer to the value list target wouldn't need all the ensureSettable
+			// calls. The final pointer makes the value list item settable.
+			elem = ensureSettable(elem)
+		}
+
+		if err := d.decodeKeyChain(remainingChain, raw, elem, state.child()); err != nil {
+			return err
+		}
+
+		val.SetMapIndex(newKey, elem)
+		return nil
+	}
+
+	if kind == reflect.Struct {
+		unescapedKey, unescapeErr := d.converter.Unescape(rawKey)
+		if unescapeErr != nil {
+			return levelKeyChain.wrapError(unescapeErr, inputStr, val)
+		}
+
+		// TODO:
+		// Struct info caching was already a priority, but the fact that this
+		// parse() call now occurs within the "for field in fields..." loop
+		// rather than outside it exacerbates the necessity.
+		items, parseErr := d.structParser.parse(val)
+		if parseErr != nil {
+			return levelKeyChain.wrapError(parseErr, inputStr, val)
+		}
+
+		item, exists := items[unescapedKey]
+		if !exists {
+			if d.ignoreInvalidKeys {
+				return nil
+			}
+
+			return levelKeyChain.newError("unknown key", inputStr, val)
+		}
+
+		childState := state.childWithSetMode(LevelValueList, item.setOpts)
+		return d.decodeKeyChain(remainingChain, raw, item.val, childState)
+	}
+
+	if d.ignoreInvalidKeys {
+		return nil
+	}
+
+	return levelKeyChain.newError("non-indexable key chain target", inputStr, val)
 }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -43,6 +43,10 @@ func queryErrorTests(t *testing.T) {
 			suite.runStructUnescapeTests(t)
 		})
 	})
+
+	if !testing.Short() {
+		t.Run("key chain", suite.runKeyChainTests)
+	}
 }
 
 func fieldErrorTests(t *testing.T) {
@@ -62,6 +66,8 @@ func fieldErrorTests(t *testing.T) {
 	t.Run("container", func(t *testing.T) {
 		t.Run("struct", suite.runStructParseTests)
 	})
+
+	t.Run("key chain", suite.runKeyChainTests)
 }
 
 func keyErrorTests(t *testing.T) {
@@ -163,6 +169,8 @@ func runQuerySuccessTests(t *testing.T) {
 
 		t.Run("struct", suite.runStructQueryTests)
 	})
+
+	t.Run("key chain", suite.runKeyChainQueryTests)
 }
 
 func runFieldSuccessTests(t *testing.T) {
@@ -197,6 +205,8 @@ func runFieldSuccessTests(t *testing.T) {
 
 		t.Run("struct", suite.runStructFieldTests)
 	})
+
+	t.Run("key chain", suite.runKeyChainFieldTests)
 }
 
 func runKeySuccessTests(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/oligarch316/qry
 go 1.13
 
 require (
+	github.com/disiqueira/gotree v1.0.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	go.uber.org/zap v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/disiqueira/gotree v1.0.0 h1:en5wk87n7/Jyk6gVME3cx3xN9KmUCstJ1IjHr4Se4To=
+github.com/disiqueira/gotree v1.0.0/go.mod h1:7CwL+VWsWAU95DovkdRZAtA7YbtHwGk+tLV/kNi8niU=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=

--- a/separator.go
+++ b/separator.go
@@ -4,9 +4,12 @@ import "strings"
 
 // ConfigSeparate TODO
 type ConfigSeparate struct {
-	Fields, Values func(string) []string
-	KeyVals        func(string) (string, string)
+	Fields, Values, KeyChain func(string) []string
+	KeyVals                  func(string) (string, string)
 }
+
+func separateNoopSplit(s string) []string        { return []string{s} }
+func separateNoopPair(s string) (string, string) { return s, "" }
 
 type separatorSet map[rune]struct{}
 

--- a/suite_keychain_test.go
+++ b/suite_keychain_test.go
@@ -12,7 +12,7 @@ import (
 
 // NOTE:
 // Unescape and structparser error testing when decoding structs is left
-// to the "struct family" or error tests, despite occuring with the
+// to the "struct family" of error tests, despite occuring within the
 // decodeKeyChain(...) function.
 
 func (des decodeErrorSuite) runKeyChainTests(t *testing.T) {

--- a/suite_keychain_test.go
+++ b/suite_keychain_test.go
@@ -1,0 +1,218 @@
+package qry_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ===== Error
+func (des decodeErrorSuite) runKeyChainTests(t *testing.T) {
+	t.Skip("TODO")
+
+	// Unknown key
+	// Non-indexable target type
+}
+
+// ===== Success
+
+// ----- Query
+func (dss decodeSuccessSuite) runKeyChainQueryTests(t *testing.T) {
+	t.Run("map chain", dss.runKeyChainQueryMapSubtests)
+	t.Run("struct chain", dss.runKeyChainQueryStructSubtests)
+	t.Run("mixed chain", dss.runKeyChainQueryMixedSubtests)
+}
+
+func (dss decodeSuccessSuite) runKeyChainQueryMapSubtests(t *testing.T) {
+	var (
+		input  = "keyA.keyX=val%20AX&keyB.keyX=val%20BX"
+		runner = dss.withKeyChainSep('.')
+	)
+
+	runner.runSubtest(t, "map[string]map[string]string", func(t *testing.T, decode tDecode) {
+		var (
+			target = map[string]map[string]string{
+				"keyA": map[string]string{"keyX": "orig AX"},
+				"keyB": map[string]string{"keyX": "orig BX"},
+			}
+			expected = map[string]map[string]string{
+				"keyA": map[string]string{"keyX": "val AX"},
+				"keyB": map[string]string{"keyX": "val BX"},
+			}
+		)
+
+		decode(input, &target)
+		assert.Equal(t, expected, target)
+	})
+
+	runner.runSubtest(t, "map[string]map[string]*string", func(t *testing.T, decode tDecode) {
+		var (
+			originalBX = "orig BX"
+			originalBY = "orig BY"
+			target     = map[string]map[string]*string{
+				"keyB": map[string]*string{
+					"keyX": &originalBX,
+					"keyY": &originalBY,
+				},
+			}
+
+			expectedAX = "val AX"
+			expectedBX = "val BX"
+			expectedBY = "orig BY"
+			expected   = map[string]map[string]*string{
+				"keyA": map[string]*string{"keyX": &expectedAX},
+				"keyB": map[string]*string{
+					"keyX": &expectedBX,
+					"keyY": &expectedBY,
+				},
+			}
+		)
+
+		decode(input, &target)
+		require.Equal(t, expected, target)
+		assert.Equal(t, "val BX", originalBX)
+		assert.Equal(t, "orig BY", originalBY)
+	})
+
+	runner.runSubtest(t, "map[string]*map[string]*string", func(t *testing.T, decode tDecode) {
+		var (
+			originalBX, originalBY = "orig BX", "orig BY"
+			originalB              = map[string]*string{
+				"keyX": &originalBX,
+				"keyY": &originalBY,
+			}
+			target = map[string]*map[string]*string{"keyB": &originalB}
+
+			expectedAX             = "val AX"
+			expectedA              = map[string]*string{"keyX": &expectedAX}
+			expectedBX, expectedBY = "val BX", "orig BY"
+			expectedB              = map[string]*string{
+				"keyX": &expectedBX,
+				"keyY": &expectedBY,
+			}
+			expected = map[string]*map[string]*string{
+				"keyA": &expectedA,
+				"keyB": &expectedB,
+			}
+		)
+
+		decode(input, &target)
+		require.Equal(t, expected, target)
+		require.Equal(t, expectedB, originalB)
+		assert.Equal(t, "val BX", originalBX)
+		assert.Equal(t, "orig BY", originalBY)
+	})
+}
+
+type (
+	tKeyChainQueryXY struct {
+		KeyX string
+		KeyY *string
+	}
+
+	tKeyChainQueryAB struct {
+		KeyA tKeyChainQueryXY
+		KeyB *tKeyChainQueryXY
+	}
+)
+
+func (dss decodeSuccessSuite) runKeyChainQueryStructSubtests(t *testing.T) {
+	var (
+		input  = "keyA.keyX=val%20AX&keyA.keyY=val%20AY&keyB.keyX=val%20BX&keyB.keyY=val%20BY"
+		runner = dss.withKeyChainSep('.')
+	)
+
+	runner.runTest(t, func(t *testing.T, decode tDecode) {
+		var (
+			originalAY, originalBY = "orig AY", "orig BY"
+			originalB              = tKeyChainQueryXY{
+				KeyX: "orig BX",
+				KeyY: &originalBY,
+			}
+			target = tKeyChainQueryAB{
+				KeyA: tKeyChainQueryXY{
+					KeyX: "orig AX",
+					KeyY: &originalAY,
+				},
+				KeyB: &originalB,
+			}
+		)
+
+		decode(input, &target)
+
+		t.Run("KeyA.KeyX struct.string", func(t *testing.T) {
+			assert.Equal(t, "val AX", target.KeyA.KeyX)
+		})
+
+		t.Run("KeyA.KeyY struct.*string", func(t *testing.T) {
+			require.Equal(t, "val AY", *target.KeyA.KeyY)
+			assert.Equal(t, "val AY", originalAY)
+		})
+
+		t.Run("KeyB.KeyX *struct.string", func(t *testing.T) {
+			require.Equal(t, "val BX", target.KeyB.KeyX)
+			assert.Equal(t, "val BX", originalB.KeyX)
+		})
+
+		t.Run("KeyB.KeyY *struct.*string", func(t *testing.T) {
+			require.Equal(t, "val BY", *target.KeyB.KeyY)
+			require.Equal(t, "val BY", *originalB.KeyY)
+			assert.Equal(t, "val BY", originalBY)
+		})
+	})
+
+	t.Run("various embedded struct|*struct tests", func(t *testing.T) {
+		t.Skip("TODO")
+	})
+}
+
+func (dss decodeSuccessSuite) runKeyChainQueryMixedSubtests(t *testing.T) {
+	var (
+		input  = "keyA.keyX=val%20AX"
+		runner = dss.withKeyChainSep('.')
+	)
+
+	runner.runSubtest(t, "map[string]*struct{ KeyX *string }", func(t *testing.T, decode tDecode) {
+		var (
+			originalAX, originalBX = "orig AX", "orig BX"
+			target                 = map[string]*struct{ KeyX *string }{
+				"keyA": &struct{ KeyX *string }{KeyX: &originalAX},
+				"keyB": &struct{ KeyX *string }{KeyX: &originalBX},
+			}
+
+			expectedAX, expectedBX = "val AX", "orig BX"
+			expected               = map[string]*struct{ KeyX *string }{
+				"keyA": &struct{ KeyX *string }{KeyX: &expectedAX},
+				"keyB": &struct{ KeyX *string }{KeyX: &expectedBX},
+			}
+		)
+
+		decode(input, &target)
+		require.Equal(t, expected, target)
+		assert.Equal(t, "val AX", originalAX)
+		assert.Equal(t, "orig BX", originalBX)
+	})
+
+	runner.runSubtest(t, "struct{ KeyA *map[string]*string }", func(t *testing.T, decode tDecode) {
+		var (
+			originalAX, originalAY = "orig AX", "orig AY"
+			originalA              = map[string]*string{"keyX": &originalAX, "keyY": &originalAY}
+			target                 = struct{ KeyA *map[string]*string }{KeyA: &originalA}
+
+			expectedAX, expectedAY = "val AX", "orig AY"
+			expectedA              = map[string]*string{"keyX": &expectedAX, "keyY": &expectedAY}
+			expected               = struct{ KeyA *map[string]*string }{KeyA: &expectedA}
+		)
+
+		decode(input, &target)
+		require.Equal(t, expected, target)
+		assert.Equal(t, "val AX", originalAX)
+		assert.Equal(t, "orig AY", originalAY)
+	})
+}
+
+// ----- Field
+func (dss decodeSuccessSuite) runKeyChainFieldTests(t *testing.T) {
+	t.Skip("TODO")
+}

--- a/suite_keychain_test.go
+++ b/suite_keychain_test.go
@@ -3,16 +3,38 @@ package qry_test
 import (
 	"testing"
 
+	"github.com/oligarch316/qry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // ===== Error
-func (des decodeErrorSuite) runKeyChainTests(t *testing.T) {
-	t.Skip("TODO")
 
-	// Unknown key
-	// Non-indexable target type
+// NOTE:
+// Unescape and structparser error testing when decoding structs is left
+// to the "struct family" or error tests, despite occuring with the
+// decodeKeyChain(...) function.
+
+func (des decodeErrorSuite) runKeyChainTests(t *testing.T) {
+	var (
+		input  = "keyA.keyX=val%20AX"
+		runner = des.with(
+			qry.SeparateKeyChainBy('.'),
+			qry.IgnoreInvalidKeys(false),
+		)
+	)
+
+	runner.runSubtest(t, "non-indexable target error", func(t *testing.T, decode tDecode) {
+		var target map[string]string
+		actual := decode(input, &target)
+		assertErrorMessage(t, "non-indexable key chain target", actual)
+	})
+
+	runner.runSubtest(t, "unknown key error", func(t *testing.T, decode tDecode) {
+		var target map[string]struct{ KeyOther string }
+		actual := decode(input, &target)
+		assertErrorMessage(t, "unknown key", actual)
+	})
 }
 
 // ===== Success


### PR DESCRIPTION
**Added:**
- Key chaining functionality
Separate raw key strings into a list of keys. Descend maps/structs at the query level and maps at the field level (child structs included) via key list when decoding

- IgnoreInvalidKeys config option
Configurable skip vs. error when encountering invalid key/key chain

- TreeTrace printing
Was a planned bugfix, but had to be done with this change as key chains introduced panic behavior pretty quickly

**Issues:**
- Unexported DecodeLevels
Root and key chain decode levels are unexported as they shouldn't be used for configuration, but this makes interpreting DecodeInfo (involved in errors/traces) annoying

- Need for struct info caching exacerbated
`structparser.parse(...)` has been moved into a loop making the lack of a cache for those results worse

- DecodeInfo `Input` field abuse
Key chain decode level does formatting to wedge multiple strings considered "input" into DecodeInfo's `Input` field for errors/tracing. This detracts from the nice structured nature of DecodeInfo