### PR TITLE
Feature/robust struct tags

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -44,38 +44,42 @@ func (de DecodeError) Error() string {
 // DecodeLevel TODO
 type DecodeLevel int
 
+const levelInvalid DecodeLevel = 0
+
 // Level TODO
 const (
-	// Public levels
-	LevelInvalid DecodeLevel = iota
-	LevelQuery
+	LevelQuery DecodeLevel = iota + 1
 	LevelField
 	LevelKey
 	LevelValueList
 	LevelValue
 
-	// TODO: This internal level stuff makes acting on DecodeInfo annoying.
-	// Maybe try a second type like:
-	// type DecodeSetLevel|DecodePublicLevel|... DecodeLevel
-
-	// Internal levels
-	levelRoot
-	levelKeyChain
+	// Return only
+	LevelRoot
+	LevelKeyChain
 )
 
 var decodeLevelNames = map[DecodeLevel]string{
-	LevelInvalid:   "invalid",
+	levelInvalid: "invalid",
+
 	LevelQuery:     "query",
 	LevelField:     "field",
 	LevelKey:       "key",
 	LevelValueList: "value list",
 	LevelValue:     "value",
 
-	levelRoot:     "root",
-	levelKeyChain: "key chain",
+	LevelRoot:     "root",
+	LevelKeyChain: "key chain",
 }
 
-func (dl DecodeLevel) String() string { return decodeLevelNames[dl] }
+func (dl DecodeLevel) String() string {
+	if name, ok := decodeLevelNames[dl]; ok {
+		return name
+	}
+	return decodeLevelNames[levelInvalid]
+}
+
+func (dl DecodeLevel) validInput() bool { return dl > levelInvalid && dl < LevelRoot }
 
 func (dl DecodeLevel) newDefault() reflect.Value {
 	switch dl {
@@ -133,7 +137,7 @@ type Decoder struct {
 }
 
 // NewDecoder TODO: friendly.go
-func NewDecoder(opts ...Option) *Decoder { return NewConfig().NewDecoder(opts...) }
+func NewDecoder(opts ...Option) (*Decoder, error) { return NewConfig().NewDecoder(opts...) }
 
 // Unescape TODO: friendly.go
 func (d *Decoder) Unescape(s string) (string, error) { return d.converter.Unescape(s) }
@@ -168,10 +172,12 @@ func (d *Decoder) Decode(level DecodeLevel, input string, v interface{}, traces 
 	val := reflect.ValueOf(v)
 
 	switch {
+	case !level.validInput():
+		return LevelRoot.newError("invalid decode level: "+level.String(), input, val)
 	case val.Kind() != reflect.Ptr:
-		return levelRoot.newError("non-pointer target", input, val)
+		return LevelRoot.newError("non-pointer target", input, val)
 	case val.IsNil():
-		return levelRoot.newError("nil pointer target", input, val)
+		return LevelRoot.newError("nil pointer target", input, val)
 	}
 
 	if d.logTrace != nil {
@@ -493,7 +499,7 @@ func (d *Decoder) handleContainers(level DecodeLevel, raw string, val reflect.Va
 
 			// TODO: magic => constant
 			if item, ok := items["key"]; ok {
-				childState := state.childWithSetMode(LevelKey, item.setOpts)
+				childState := state.childWithSetOpts(item.SetOptions(LevelKey))
 				if err := d.decode(LevelKey, rawKey, item.val, childState); err != nil {
 					return true, err
 				}
@@ -501,7 +507,7 @@ func (d *Decoder) handleContainers(level DecodeLevel, raw string, val reflect.Va
 
 			// TODO: magic => constant
 			if item, ok := items["values"]; ok {
-				childState := state.childWithSetMode(LevelValueList, item.setOpts)
+				childState := state.childWithSetOpts(item.SetOptions(LevelValueList))
 				if err := d.decode(LevelValueList, rawValueList, item.val, childState); err != nil {
 					return true, err
 				}
@@ -533,7 +539,7 @@ func (d *Decoder) decodeKeyChain(rawChain []string, raw string, val reflect.Valu
 	// just checking for nil rather than a noop function for "no trace"
 	inputStr := fmt.Sprintf("%s | %s", strings.Join(rawChain, ", "), raw)
 
-	state.trace.Mark(levelKeyChain, inputStr, val)
+	state.trace.Mark(LevelKeyChain, inputStr, val)
 
 	kind := val.Kind()
 
@@ -587,7 +593,7 @@ func (d *Decoder) decodeKeyChain(rawChain []string, raw string, val reflect.Valu
 	if kind == reflect.Struct {
 		unescapedKey, unescapeErr := d.converter.Unescape(rawKey)
 		if unescapeErr != nil {
-			return levelKeyChain.wrapError(unescapeErr, inputStr, val)
+			return LevelKeyChain.wrapError(unescapeErr, inputStr, val)
 		}
 
 		// TODO:
@@ -596,7 +602,7 @@ func (d *Decoder) decodeKeyChain(rawChain []string, raw string, val reflect.Valu
 		// rather than outside it exacerbates the necessity.
 		items, parseErr := d.structParser.parse(val)
 		if parseErr != nil {
-			return levelKeyChain.wrapError(parseErr, inputStr, val)
+			return LevelKeyChain.wrapError(parseErr, inputStr, val)
 		}
 
 		item, exists := items[unescapedKey]
@@ -605,10 +611,10 @@ func (d *Decoder) decodeKeyChain(rawChain []string, raw string, val reflect.Valu
 				return nil
 			}
 
-			return levelKeyChain.newError("unknown key", inputStr, val)
+			return LevelKeyChain.newError("unknown key", inputStr, val)
 		}
 
-		childState := state.childWithSetMode(LevelValueList, item.setOpts)
+		childState := state.childWithSetOpts(item.SetOptions(LevelValueList))
 		return d.decodeKeyChain(remainingChain, raw, item.val, childState)
 	}
 
@@ -616,5 +622,5 @@ func (d *Decoder) decodeKeyChain(rawChain []string, raw string, val reflect.Valu
 		return nil
 	}
 
-	return levelKeyChain.newError("non-indexable key chain target", inputStr, val)
+	return LevelKeyChain.newError("non-indexable key chain target", inputStr, val)
 }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -8,6 +8,8 @@ import (
 
 // ===== Error
 func TestError(t *testing.T) {
+	// TODO: Test Decode(...) with invalid decode level
+
 	t.Run("query", queryErrorTests)
 	t.Run("field", fieldErrorTests)
 	t.Run("key", keyErrorTests)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -46,9 +46,7 @@ func queryErrorTests(t *testing.T) {
 		})
 	})
 
-	if !testing.Short() {
-		t.Run("key chain", suite.runKeyChainTests)
-	}
+	t.Run("key chain", suite.runKeyChainTests)
 }
 
 func fieldErrorTests(t *testing.T) {
@@ -68,8 +66,6 @@ func fieldErrorTests(t *testing.T) {
 	t.Run("container", func(t *testing.T) {
 		t.Run("struct", suite.runStructParseTests)
 	})
-
-	t.Run("key chain", suite.runKeyChainTests)
 }
 
 func keyErrorTests(t *testing.T) {
@@ -172,7 +168,7 @@ func runQuerySuccessTests(t *testing.T) {
 		t.Run("struct", suite.runStructQueryTests)
 	})
 
-	t.Run("key chain", suite.runKeyChainQueryTests)
+	t.Run("key chain", suite.runKeyChainTests)
 }
 
 func runFieldSuccessTests(t *testing.T) {
@@ -207,8 +203,6 @@ func runFieldSuccessTests(t *testing.T) {
 
 		t.Run("struct", suite.runStructFieldTests)
 	})
-
-	t.Run("key chain", suite.runKeyChainFieldTests)
 }
 
 func runKeySuccessTests(t *testing.T) {

--- a/structparser.go
+++ b/structparser.go
@@ -10,10 +10,23 @@ import (
 )
 
 const (
-	sTagSep            = ","
-	sTagOmit           = "-"
-	sTagDirectiveEmbed = "embed"
+	sTagSep        = ","
+	sTagOmit       = "-"
+	sTagOmitEscape = sTagOmit + sTagSep
+
+	sTagBaseEmbed   = "embed"
+	sTagBaseRequire = "require"
+
+	sTagSetSep = "="
 )
+
+var sTagSetLevelNames = map[string]DecodeLevel{
+	"query":     LevelQuery,
+	"field":     LevelField,
+	"key":       LevelKey,
+	"valueList": LevelValueList,
+	"value":     LevelValue,
+}
 
 // StructFieldError TODO
 type StructFieldError struct {
@@ -30,22 +43,20 @@ func (sfe StructFieldError) Error() string {
 
 // StructFieldInfo TODO
 type StructFieldInfo struct {
-	Name string
-	Type reflect.Type
+	Tagged bool
 
-	anonymous  bool
-	exported   bool
-	tagName    string
-	tagEmbed   bool
-	tagSetOpts []SetOption
+	fieldInfo
+	baseTagInfo
+	setTagInfo
 }
 
 // DecodeName TODO
 func (sfi StructFieldInfo) DecodeName() string {
 	switch {
-	case sfi.tagName != "":
-		return sfi.tagName
+	case sfi.TagName != "":
+		return sfi.TagName
 	case sfi.Name == "":
+		// TODO: Is this possible?
 		return ""
 	}
 
@@ -54,26 +65,149 @@ func (sfi StructFieldInfo) DecodeName() string {
 	return string(unicode.ToLower(r)) + sfi.Name[n:]
 }
 
-func (sfi StructFieldInfo) String() string {
-	if sfi.anonymous {
-		return fmt.Sprintf("%s (%s)", sfi.Type, sfi.Type.Kind())
-	}
-	return fmt.Sprintf("%s %s (%s)", sfi.Name, sfi.Type, sfi.Type.Kind())
+func (sfi StructFieldInfo) wrapError(err error) StructFieldError {
+	return StructFieldError{StructFieldInfo: sfi, err: err}
 }
 
 func (sfi StructFieldInfo) newError(msg string) StructFieldError {
-	return StructFieldError{
-		StructFieldInfo: sfi,
-		err:             errors.New(msg),
+	return sfi.wrapError(errors.New(msg))
+}
+
+type fieldInfo struct {
+	Anonymous, Exported bool
+	Name                string
+	Type                reflect.Type
+}
+
+func (fi fieldInfo) String() string {
+	if fi.Anonymous {
+		return fmt.Sprintf("%s (%s)", fi.Type, fi.Type.Kind())
 	}
+	return fmt.Sprintf("%s %s (%s)", fi.Name, fi.Type, fi.Type.Kind())
+}
+
+type baseTagInfo struct {
+	TagName                       string
+	TagEmbed, TagOmit, TagRequire bool
+}
+
+func (bti *baseTagInfo) parse(raw string) error {
+	switch raw {
+	case "":
+		// `qry:""`
+		return errors.New("empty base tag")
+	case sTagOmit:
+		// `qry:"-"`
+		bti.TagOmit = true
+		return nil
+	case sTagOmitEscape:
+		// `qry:"-,"`
+		bti.TagName = sTagOmit
+		return nil
+	}
+
+	items := strings.Split(raw, sTagSep)
+	bti.TagName, items = items[0], items[1:]
+
+	for _, item := range items {
+		switch item {
+		case sTagBaseEmbed:
+			bti.TagEmbed = true
+		case sTagBaseRequire:
+			bti.TagRequire = true
+		default:
+			return fmt.Errorf("invalid base tag directive '%s'", item)
+		}
+	}
+
+	// Ensure no incompatible tag directives
+	if bti.TagEmbed {
+		switch {
+		case bti.TagName != "":
+			return errors.New("mutually exclusive base tag directive 'embed' and non-empty name")
+		case bti.TagRequire:
+			return errors.New("mutually exclusive base tag directives 'embed' and 'require'")
+		}
+	}
+
+	return nil
+}
+
+type setTagInfo struct {
+	explicitSetOpts SetOptionsMap
+	defaultSetOpts  []SetOption
+}
+
+func (sti setTagInfo) SetOptions(defaultLevel DecodeLevel) SetOptionsMap {
+	if len(sti.defaultSetOpts) < 1 {
+		return sti.explicitSetOpts
+	}
+
+	res := SetOptionsMap{defaultLevel: sti.defaultSetOpts}
+	for level, opts := range sti.explicitSetOpts {
+		res[level] = opts
+	}
+	return res
+}
+
+func (sti *setTagInfo) parse(raw string) error {
+	if raw == "" {
+		// `qrySet:""`
+		return errors.New("empty set tag")
+	}
+
+	items := strings.Split(raw, sTagSep)
+	for _, item := range items {
+		var (
+			split = strings.SplitN(item, sTagSetSep, 2)
+			err   error
+		)
+
+		if len(split) == 1 {
+			err = sti.parseDefaultOpt(split[0])
+		} else {
+			err = sti.parseExplicitOpt(split[0], split[1])
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (sti *setTagInfo) parseDefaultOpt(rawOpt string) error {
+	if opt := SetOption(rawOpt); opt.valid() {
+		sti.defaultSetOpts = append(sti.defaultSetOpts, opt)
+		return nil
+	}
+	return fmt.Errorf("invalid set tag option '%s'", rawOpt)
+}
+
+func (sti *setTagInfo) parseExplicitOpt(rawLevel, rawOpt string) error {
+	var (
+		level = sTagSetLevelNames[rawLevel]
+		opt   = SetOption(rawOpt)
+	)
+
+	switch {
+	case !level.validInput():
+		return fmt.Errorf("invalid set tag level '%s'", rawLevel)
+	case !opt.valid():
+		return fmt.Errorf("invalid set tag option '%s'", rawOpt)
+	}
+
+	sti.explicitSetOpts[level] = append(sti.explicitSetOpts[level], opt)
+	return nil
 }
 
 // ConfigStructParse TODO
-type ConfigStructParse struct{ TagName string }
+type ConfigStructParse struct{ BaseTagName, SetTagName string }
 
 type structItem struct {
-	setOpts []SetOption
-	val     reflect.Value
+	val reflect.Value
+	setTagInfo
 }
 
 type structParser struct {
@@ -88,34 +222,45 @@ func newStructParser(cfg ConfigStructParse, checkUnmarshaler func(reflect.Type) 
 	}
 }
 
-func (sp structParser) loadFieldInfo(field reflect.StructField) (*StructFieldInfo, bool) {
-	rawTag := field.Tag.Get(sp.TagName)
-	if rawTag == sTagOmit {
-		return nil, true
-	}
-
-	items := strings.Split(rawTag, sTagSep)
-	res := &StructFieldInfo{
-		Name:      field.Name,
-		Type:      field.Type,
-		anonymous: field.Anonymous,
-		exported:  field.PkgPath == "",
-		tagName:   items[0],
-	}
-
-	for _, item := range items[1:] {
-		// TODO: is continue on empty string worthwhile here?
-		// - no change in correctness, just eliminate a useless arg to childWithSetMode()
-		// - special mention only because it is technically part of the spec given
-		//   parsing a key of name "-" requires a tag `qry:"-,"` (like encoding/json)
-		if item == sTagDirectiveEmbed {
-			res.tagEmbed = true
-			continue
+func (sp structParser) parseField(field reflect.StructField) (*StructFieldInfo, error) {
+	var (
+		res = &StructFieldInfo{
+			fieldInfo: fieldInfo{
+				Anonymous: field.Anonymous,
+				Exported:  field.PkgPath == "",
+				Name:      field.Name,
+				Type:      field.Type,
+			},
 		}
-		res.tagSetOpts = append(res.tagSetOpts, SetOption(item))
+
+		rawBaseTag, rawSetTag       string
+		baseTagExists, setTagExists bool
+	)
+
+	if rawBaseTag, baseTagExists = field.Tag.Lookup(sp.BaseTagName); baseTagExists {
+		if err := res.baseTagInfo.parse(rawBaseTag); err != nil {
+			return nil, res.wrapError(err)
+		}
 	}
 
-	return res, false
+	if rawSetTag, setTagExists = field.Tag.Lookup(sp.SetTagName); setTagExists {
+		if err := res.setTagInfo.parse(rawSetTag); err != nil {
+			return nil, res.wrapError(err)
+		}
+	}
+
+	// Ensure no incompatible settings between base and set tags
+	if setTagExists {
+		switch {
+		case res.TagOmit:
+			return nil, res.newError("mutually exclusive base tag name '-' (omit) and set tag options")
+		case res.TagEmbed:
+			return nil, res.newError("mutually exclusive base tag directive 'embed' and set tag options")
+		}
+	}
+
+	res.Tagged = baseTagExists || setTagExists
+	return res, nil
 }
 
 func (sp structParser) canUnmarshal(sfi *StructFieldInfo) bool {
@@ -127,7 +272,7 @@ func (sp structParser) canUnmarshal(sfi *StructFieldInfo) bool {
 		       ==implies=> field is addressable
 		       ==implies=> PtrTo check required
 	*/
-	return !sfi.exported && (sp.checkUnmarshaler(sfi.Type) || sp.checkUnmarshaler(reflect.PtrTo(sfi.Type)))
+	return !sfi.Exported && (sp.checkUnmarshaler(sfi.Type) || sp.checkUnmarshaler(reflect.PtrTo(sfi.Type)))
 }
 
 func (sp structParser) parse(val reflect.Value) (map[string]structItem, error) {
@@ -147,17 +292,17 @@ func (sp structParser) parse(val reflect.Value) (map[string]structItem, error) {
 		)
 
 		for i := 0; i < nFields; i++ {
-			fieldInfo, omitted := sp.loadFieldInfo(sType.Field(i))
-			if omitted {
+			fieldInfo, fieldErr := sp.parseField(sType.Field(i))
+			switch {
+			case fieldErr != nil:
+				return nil, fieldErr
+			case fieldInfo.TagOmit:
 				continue
 			}
 
 			// Explicit embed
-			if fieldInfo.tagEmbed {
-				switch {
-				case fieldInfo.tagName != "":
-					return nil, fieldInfo.newError("mutually exclusive non-empty name and embed directives")
-				case !fieldInfo.anonymous && !fieldInfo.exported:
+			if fieldInfo.TagEmbed {
+				if !fieldInfo.Anonymous && !fieldInfo.Exported {
 					/*
 						NOTE:
 						We could *almost* disallow 'embed' on anonymous fields,
@@ -168,21 +313,23 @@ func (sp structParser) parse(val reflect.Value) (map[string]structItem, error) {
 						> `pathological/anonymous exported embedded unmarshaler`
 						> `pathological/anonymous unexported embedded unmarshaler`
 					*/
-					return nil, fieldInfo.newError("embed directive on non-anonymous unexported field")
+					return nil, fieldInfo.newError("'embed' directive on non-anonymous unexported field")
 				}
 
 				switch fieldInfo.Type.Kind() {
 				case reflect.Struct:
+					// Unexported structs are fine as we can work with their zero values directly
 					workList = append(workList, workItem.Field(i))
 					continue
 				case reflect.Ptr:
-					if !fieldInfo.exported {
-						return nil, fieldInfo.newError("embed directive on unexported pointer field")
+					if !fieldInfo.Exported {
+						// Unexported pointers are not ok, as we need to set them if they're nil (zero value)
+						return nil, fieldInfo.newError("'embed' directive on unexported pointer field")
 					}
 
 					elemType := fieldInfo.Type.Elem()
 					if elemType.Kind() != reflect.Struct {
-						return nil, fieldInfo.newError("embed directive on invalid type")
+						return nil, fieldInfo.newError("'embed' directive on invalid type")
 					}
 
 					ptrVal := workItem.Field(i)
@@ -194,11 +341,11 @@ func (sp structParser) parse(val reflect.Value) (map[string]structItem, error) {
 					continue
 				}
 
-				return nil, fieldInfo.newError("embed directive on invalid type")
+				return nil, fieldInfo.newError("'embed' directive on invalid type")
 			}
 
 			// Possible implicit embed
-			if fieldInfo.anonymous && fieldInfo.tagName == "" && !sp.canUnmarshal(fieldInfo) {
+			if fieldInfo.Anonymous && !fieldInfo.Tagged && !sp.canUnmarshal(fieldInfo) {
 				/*
 					NOTE:
 					We could *almost* dispense with the unmarshaler check, given
@@ -213,7 +360,7 @@ func (sp structParser) parse(val reflect.Value) (map[string]structItem, error) {
 					workList = append(workList, workItem.Field(i))
 					continue
 				case reflect.Ptr:
-					if fieldInfo.exported {
+					if fieldInfo.Exported {
 						elemType := fieldInfo.Type.Elem()
 						if elemType.Kind() == reflect.Struct {
 							ptrVal := workItem.Field(i)
@@ -228,10 +375,10 @@ func (sp structParser) parse(val reflect.Value) (map[string]structItem, error) {
 				}
 			}
 
-			if !fieldInfo.exported {
+			if !fieldInfo.Exported {
 				// Return error if there's explicit intention to consider this field
-				if fieldInfo.tagName != "" {
-					return nil, fieldInfo.newError("non-empty name directive on unexported field")
+				if fieldInfo.Tagged {
+					return nil, fieldInfo.newError("tag on unexported field")
 				}
 
 				// Otherwise skip
@@ -245,8 +392,8 @@ func (sp structParser) parse(val reflect.Value) (map[string]structItem, error) {
 			// for inspiration. depth > from tag > index sounds right.
 			if _, collision := res[decodeName]; !collision {
 				res[decodeName] = structItem{
-					setOpts: fieldInfo.tagSetOpts,
-					val:     workItem.Field(i),
+					val:        workItem.Field(i),
+					setTagInfo: fieldInfo.setTagInfo,
 				}
 			}
 		}

--- a/structparser.go
+++ b/structparser.go
@@ -14,8 +14,7 @@ const (
 	sTagOmit       = "-"
 	sTagOmitEscape = sTagOmit + sTagSep
 
-	sTagBaseEmbed   = "embed"
-	sTagBaseRequire = "require"
+	sTagBaseEmbed = "embed"
 
 	sTagSetSep = "="
 )
@@ -87,8 +86,8 @@ func (fi fieldInfo) String() string {
 }
 
 type baseTagInfo struct {
-	TagName                       string
-	TagEmbed, TagOmit, TagRequire bool
+	TagName           string
+	TagEmbed, TagOmit bool
 }
 
 func (bti *baseTagInfo) parse(raw string) error {
@@ -110,24 +109,17 @@ func (bti *baseTagInfo) parse(raw string) error {
 	bti.TagName, items = items[0], items[1:]
 
 	for _, item := range items {
-		switch item {
-		case sTagBaseEmbed:
+		if item == sTagBaseEmbed {
 			bti.TagEmbed = true
-		case sTagBaseRequire:
-			bti.TagRequire = true
-		default:
-			return fmt.Errorf("invalid base tag directive '%s'", item)
+			continue
 		}
+
+		return fmt.Errorf("invalid base tag directive '%s'", item)
 	}
 
 	// Ensure no incompatible tag directives
-	if bti.TagEmbed {
-		switch {
-		case bti.TagName != "":
-			return errors.New("mutually exclusive base tag directive 'embed' and non-empty name")
-		case bti.TagRequire:
-			return errors.New("mutually exclusive base tag directives 'embed' and 'require'")
-		}
+	if bti.TagEmbed && bti.TagName != "" {
+		return errors.New("mutually exclusive base tag directive 'embed' and non-empty name")
 	}
 
 	return nil

--- a/suite_decode_test.go
+++ b/suite_decode_test.go
@@ -75,10 +75,10 @@ func (decodeRunner) dumpTraceOnFailure(t *testing.T, trace *qry.TraceTree) {
 
 func (dr decodeRunner) runTest(t *testing.T, test decodeTest) {
 	// Setup
-	var (
-		decoder = qry.NewDecoder(dr.opts...)
-		trace   = qry.NewTraceTree()
-	)
+	decoder, err := qry.NewDecoder(dr.opts...)
+	require.NoError(t, err, "decoder creation")
+
+	trace := qry.NewTraceTree()
 
 	// Teardown
 	if testing.Verbose() {

--- a/suite_keychain_test.go
+++ b/suite_keychain_test.go
@@ -39,14 +39,13 @@ func (des decodeErrorSuite) runKeyChainTests(t *testing.T) {
 
 // ===== Success
 
-// ----- Query
-func (dss decodeSuccessSuite) runKeyChainQueryTests(t *testing.T) {
-	t.Run("map chain", dss.runKeyChainQueryMapSubtests)
-	t.Run("struct chain", dss.runKeyChainQueryStructSubtests)
-	t.Run("mixed chain", dss.runKeyChainQueryMixedSubtests)
+func (dss decodeSuccessSuite) runKeyChainTests(t *testing.T) {
+	t.Run("map chain", dss.runKeyChainMapSubtests)
+	t.Run("struct chain", dss.runKeyChainStructSubtests)
+	t.Run("mixed chain", dss.runKeyChainMixedSubtests)
 }
 
-func (dss decodeSuccessSuite) runKeyChainQueryMapSubtests(t *testing.T) {
+func (dss decodeSuccessSuite) runKeyChainMapSubtests(t *testing.T) {
 	var (
 		input  = "keyA.keyX=val%20AX&keyB.keyX=val%20BX"
 		runner = dss.withKeyChainSep('.')
@@ -128,21 +127,21 @@ func (dss decodeSuccessSuite) runKeyChainQueryMapSubtests(t *testing.T) {
 }
 
 type (
-	tKeyChainQueryXY struct {
+	tKeyChainXY struct {
 		KeyX string
 		KeyY *string
 	}
 
-	tKeyChainQueryEmbeddedC struct{ KeyC tKeyChainQueryXY }
+	tKeyChainEmbeddedC struct{ KeyC tKeyChainXY }
 
-	tKeyChainQueryAB struct {
-		KeyA tKeyChainQueryXY
-		KeyB *tKeyChainQueryXY
-		tKeyChainQueryEmbeddedC
+	tKeyChainAB struct {
+		KeyA tKeyChainXY
+		KeyB *tKeyChainXY
+		tKeyChainEmbeddedC
 	}
 )
 
-func (dss decodeSuccessSuite) runKeyChainQueryStructSubtests(t *testing.T) {
+func (dss decodeSuccessSuite) runKeyChainStructSubtests(t *testing.T) {
 	var (
 		input = "keyA.keyX=val%20AX&keyA.keyY=val%20AY" +
 			"&keyB.keyX=val%20BX&keyB.keyY=val%20BY" +
@@ -155,18 +154,18 @@ func (dss decodeSuccessSuite) runKeyChainQueryStructSubtests(t *testing.T) {
 		var (
 			originalAY, originalBY, originalCY = "orig AY", "orig BY", "orig CY"
 
-			originalB = tKeyChainQueryXY{
+			originalB = tKeyChainXY{
 				KeyX: "orig BX",
 				KeyY: &originalBY,
 			}
-			target = tKeyChainQueryAB{
-				KeyA: tKeyChainQueryXY{
+			target = tKeyChainAB{
+				KeyA: tKeyChainXY{
 					KeyX: "orig AX",
 					KeyY: &originalAY,
 				},
 				KeyB: &originalB,
-				tKeyChainQueryEmbeddedC: tKeyChainQueryEmbeddedC{
-					KeyC: tKeyChainQueryXY{
+				tKeyChainEmbeddedC: tKeyChainEmbeddedC{
+					KeyC: tKeyChainXY{
 						KeyX: "orig CX",
 						KeyY: &originalCY,
 					},
@@ -207,7 +206,7 @@ func (dss decodeSuccessSuite) runKeyChainQueryStructSubtests(t *testing.T) {
 	})
 }
 
-func (dss decodeSuccessSuite) runKeyChainQueryMixedSubtests(t *testing.T) {
+func (dss decodeSuccessSuite) runKeyChainMixedSubtests(t *testing.T) {
 	var (
 		input  = "keyA.keyX=val%20AX"
 		runner = dss.withKeyChainSep('.')
@@ -249,41 +248,5 @@ func (dss decodeSuccessSuite) runKeyChainQueryMixedSubtests(t *testing.T) {
 		require.Equal(t, expected, target)
 		assert.Equal(t, "val AX", originalAX)
 		assert.Equal(t, "orig AY", originalAY)
-	})
-}
-
-// ----- Field
-func (dss decodeSuccessSuite) runKeyChainFieldTests(t *testing.T) {
-	// NOTE:
-	// Just the basics for field level. Leave complex cases to the query level
-	// for test brevity.
-
-	var (
-		input  = "keyA.keyX=val%20AX"
-		runner = dss.withKeyChainSep('.')
-	)
-
-	runner.runSubtest(t, "basic map chain", func(t *testing.T, decode tDecode) {
-		var (
-			target   map[string]map[string]string
-			expected = map[string]map[string]string{
-				"keyA": map[string]string{"keyX": "val AX"},
-			}
-		)
-
-		decode(input, &target)
-		assert.Equal(t, expected, target)
-	})
-
-	runner.runSubtest(t, "basic mixed chain", func(t *testing.T, decode tDecode) {
-		var (
-			target   map[string]struct{ KeyX string }
-			expected = map[string]struct{ KeyX string }{
-				"keyA": struct{ KeyX string }{KeyX: "val AX"},
-			}
-		)
-
-		decode(input, &target)
-		assert.Equal(t, expected, target)
 	})
 }

--- a/suite_struct_test.go
+++ b/suite_struct_test.go
@@ -54,14 +54,6 @@ func (des decodeErrorSuite) runStructParseTagSubtests(t *testing.T) {
 			actual := decode("xyz", &target)
 			assertErrorMessage(t, "mutually exclusive base tag directive 'embed' and non-empty name", actual)
 		})
-
-		des.runSubtest(t, "embed and require", func(t *testing.T, decode tDecode) {
-			var target struct {
-				Embedded struct{ Key string } `qry:",embed,require"`
-			}
-			actual := decode("xyz", &target)
-			assertErrorMessage(t, "mutually exclusive base tag directives 'embed' and 'require'", actual)
-		})
 	})
 
 	t.Run("set", func(t *testing.T) {

--- a/suite_struct_test.go
+++ b/suite_struct_test.go
@@ -24,74 +24,160 @@ func (des decodeErrorSuite) runStructUnescapeTests(t *testing.T) {
 }
 
 func (des decodeErrorSuite) runStructParseTests(t *testing.T) {
-	t.Run("explicit embed", func(t *testing.T) {
-		des.runSubtest(t, "non-empty tag name", func(t *testing.T, decode tDecode) {
+	t.Run("tag", des.runStructParseTagSubtests)
+	t.Run("explicit embed", des.runStructParseExplicitEmbedSubtests)
+	t.Run("tagged invalid", des.runStructParseTaggedInvalidSubtests)
+}
+
+func (des decodeErrorSuite) runStructParseTagSubtests(t *testing.T) {
+	t.Run("base", func(t *testing.T) {
+		des.runSubtest(t, "empty", func(t *testing.T, decode tDecode) {
 			var target struct {
-				Embedded struct{ Key string } `qry:"key,embed"`
+				Key string `qry:""`
 			}
 			actual := decode("xyz", &target)
-			assertErrorMessage(t, "mutually exclusive non-empty name and embed directives", actual)
+			assertErrorMessage(t, "empty base tag", actual)
 		})
 
-		des.runSubtest(t, "non-anonymous unexported", func(t *testing.T, decode tDecode) {
+		des.runSubtest(t, "unknown directive", func(t *testing.T, decode tDecode) {
 			var target struct {
-				embedded struct{ Key string } `qry:",embed"`
+				Key string `qry:",nonDirective"`
 			}
 			actual := decode("xyz", &target)
-			assertErrorMessage(t, "embed directive on non-anonymous unexported field", actual)
+			assertErrorMessage(t, "invalid base tag directive 'nonDirective'", actual)
 		})
 
-		des.runSubtest(t, "anonymous unexported pointer", func(t *testing.T, decode tDecode) {
+		des.runSubtest(t, "embed and non-empty name", func(t *testing.T, decode tDecode) {
 			var target struct {
-				*tStructError `qry:",embed"`
+				Embedded struct{ Key string } `qry:"keyA,embed"`
 			}
 			actual := decode("xyz", &target)
-			assertErrorMessage(t, "embed directive on unexported pointer field", actual)
+			assertErrorMessage(t, "mutually exclusive base tag directive 'embed' and non-empty name", actual)
 		})
 
-		des.runSubtest(t, "non-pointer non-struct", func(t *testing.T, decode tDecode) {
+		des.runSubtest(t, "embed and require", func(t *testing.T, decode tDecode) {
 			var target struct {
-				Key string `qry:",embed"`
+				Embedded struct{ Key string } `qry:",embed,require"`
 			}
 			actual := decode("xyz", &target)
-			assertErrorMessage(t, "embed directive on invalid type", actual)
-		})
-
-		des.runSubtest(t, "pointer to non-struct", func(t *testing.T, decode tDecode) {
-			var target struct {
-				Embedded *string `qry:",embed"`
-			}
-			actual := decode("xyz", &target)
-			assertErrorMessage(t, "embed directive on invalid type", actual)
+			assertErrorMessage(t, "mutually exclusive base tag directives 'embed' and 'require'", actual)
 		})
 	})
 
-	t.Run("non-empty tag name", func(t *testing.T) {
-		des.runSubtest(t, "non-anonymous unexported", func(t *testing.T, decode tDecode) {
+	t.Run("set", func(t *testing.T) {
+		des.runSubtest(t, "empty", func(t *testing.T, decode tDecode) {
 			var target struct {
-				myKey string `qry:"key"`
+				Key string `qrySet:""`
 			}
-			actual := decode("xyz", &target)
-			assertErrorMessage(t, "non-empty name directive on unexported field", actual)
+			actual := decode("xzy", &target)
+			assertErrorMessage(t, "empty set tag", actual)
 		})
 
-		des.runSubtest(t, "anonymous unexported pointer", func(t *testing.T, decode tDecode) {
+		des.runSubtest(t, "unknown default option", func(t *testing.T, decode tDecode) {
 			var target struct {
-				*tStructError `qry:"key"`
+				Key string `qrySet:"nonSetOpt"`
 			}
-			actual := decode("xyz", &target)
-			assertErrorMessage(t, "non-empty name directive on unexported field", actual)
+			actual := decode("xzy", &target)
+			assertErrorMessage(t, "invalid set tag option 'nonSetOpt'", actual)
 		})
 
-		des.runSubtest(t, "pathological anonymous unexported unmarshaler", func(t *testing.T, decode tDecode) {
+		des.runSubtest(t, "unknown explicit option", func(t *testing.T, decode tDecode) {
 			var target struct {
-				Embedded struct {
-					tStructErrorUnmarshaler `qry:"key"`
-				} `qry:",embed"`
+				Key string `qrySet:"valueList=nonSetOpt"`
 			}
-			actual := decode("xyz", &target)
-			assertErrorMessage(t, "non-empty name directive on unexported field", actual)
+			actual := decode("xzy", &target)
+			assertErrorMessage(t, "invalid set tag option 'nonSetOpt'", actual)
 		})
+
+		des.runSubtest(t, "unknown explicit level", func(t *testing.T, decode tDecode) {
+			var target struct {
+				Key string `qrySet:"nonLevel=allowLiteral"`
+			}
+			actual := decode("xzy", &target)
+			assertErrorMessage(t, "invalid set tag level 'nonLevel'", actual)
+		})
+	})
+
+	t.Run("combined", func(t *testing.T) {
+		des.runSubtest(t, "omit and set options", func(t *testing.T, decode tDecode) {
+			var target struct {
+				Key string `qry:"-" qrySet:"allowLiteral"`
+			}
+			actual := decode("xzy", &target)
+			assertErrorMessage(t, "mutually exclusive base tag name '-' (omit) and set tag options", actual)
+		})
+
+		des.runSubtest(t, "embed and set options", func(t *testing.T, decode tDecode) {
+			var target struct {
+				Embedded struct{ Key string } `qry:",embed" qrySet:"allowLiteral"`
+			}
+			actual := decode("xzy", &target)
+			assertErrorMessage(t, "mutually exclusive base tag directive 'embed' and set tag options", actual)
+		})
+	})
+}
+
+func (des decodeErrorSuite) runStructParseExplicitEmbedSubtests(t *testing.T) {
+	des.runSubtest(t, "non-anonymous unexported", func(t *testing.T, decode tDecode) {
+		var target struct {
+			embedded struct{ Key string } `qry:",embed"`
+		}
+		actual := decode("xyz", &target)
+		assertErrorMessage(t, "'embed' directive on non-anonymous unexported field", actual)
+	})
+
+	des.runSubtest(t, "anonymous unexported pointer", func(t *testing.T, decode tDecode) {
+		var target struct {
+			*tStructError `qry:",embed"`
+		}
+		actual := decode("xyz", &target)
+		assertErrorMessage(t, "'embed' directive on unexported pointer field", actual)
+	})
+
+	des.runSubtest(t, "non-pointer non-struct", func(t *testing.T, decode tDecode) {
+		var target struct {
+			Key string `qry:",embed"`
+		}
+		actual := decode("xyz", &target)
+		assertErrorMessage(t, "'embed' directive on invalid type", actual)
+	})
+
+	des.runSubtest(t, "pointer to non-struct", func(t *testing.T, decode tDecode) {
+		var target struct {
+			Embedded *string `qry:",embed"`
+		}
+		actual := decode("xyz", &target)
+		assertErrorMessage(t, "'embed' directive on invalid type", actual)
+	})
+}
+
+func (des decodeErrorSuite) runStructParseTaggedInvalidSubtests(t *testing.T) {
+	expected := "tag on unexported field"
+
+	des.runSubtest(t, "non-anonymous unexported", func(t *testing.T, decode tDecode) {
+		var target struct {
+			myKey string `qry:"key"`
+		}
+		actual := decode("xyz", &target)
+		assertErrorMessage(t, expected, actual)
+	})
+
+	des.runSubtest(t, "anonymous unexported pointer", func(t *testing.T, decode tDecode) {
+		var target struct {
+			*tStructError `qry:"key"`
+		}
+		actual := decode("xyz", &target)
+		assertErrorMessage(t, expected, actual)
+	})
+
+	des.runSubtest(t, "pathological anonymous unexported unmarshaler", func(t *testing.T, decode tDecode) {
+		var target struct {
+			Embedded struct {
+				tStructErrorUnmarshaler `qry:"key"`
+			} `qry:",embed"`
+		}
+		actual := decode("xyz", &target)
+		assertErrorMessage(t, expected, actual)
 	})
 }
 
@@ -227,16 +313,16 @@ func (dss decodeSuccessSuite) runStructQueryUpdateSubtests(t *testing.T) {
 func (dss decodeSuccessSuite) runStructQueryOmittedSubtest(t *testing.T) {
 	dss.runTest(t, func(t *testing.T, decode tDecode) {
 		var (
-			input  = "keyA=val%20A&keyB=val%20B"
+			input  = "keyA=val%20A&-=val%20hyphen"
 			target struct {
 				KeyA string `qry:"-"`
-				KeyB string `qry:"-"`
+				KeyB string `qry:"-,"`
 			}
 		)
 
 		decode(input, &target)
 		assert.Equal(t, "", target.KeyA)
-		assert.Equal(t, "", target.KeyB)
+		assert.Equal(t, "val hyphen", target.KeyB)
 	})
 }
 


### PR DESCRIPTION
**Added:**
- Single struct tag separated into:
  - **base** tag for custom naming, omit and and embed directives
  - **set** tag for set option directives
- Clear errors on any tag misuse + testing of said errors
- Remove key chaining logic from the field level
- Re-export all decode levels + errors on misuse
- No unexported `Config` fields

**Bugfixes:**
- Spelling fix in `state.go`: diallowLiteral => disallowLiteral

**Issues:**
- Multiple string mappings for `DecodeLevel`, one for `String()` method and another (different) for parsing set tags on struct fields. Needs to be simplified/coordinated